### PR TITLE
4 - Não utilize filtros repetidos

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -159,7 +159,7 @@ describe('2 - Filtre a tabela através de um texto, inserido num *campo de texto
   });
 });
 
-describe.only('3 - Crie um filtro para valores numéricos', () => {
+describe('3 - Crie um filtro para valores numéricos', () => {
   beforeAll(mockFetch);
   beforeEach(cleanup);
 
@@ -249,7 +249,7 @@ describe.only('3 - Crie um filtro para valores numéricos', () => {
   });
 });
 
-describe('4 - Não utilize filtros repetidos', () => {
+describe.only('4 - Não utilize filtros repetidos', () => {
   beforeAll(mockFetch);
   beforeEach(cleanup);
 

--- a/src/components/FilterForm.jsx
+++ b/src/components/FilterForm.jsx
@@ -4,6 +4,7 @@ import planetsContext from '../contextAPI';
 function FilterForm() {
   const { filters: { filterByName: { name } } } = useContext(planetsContext);
   const {
+    columnOptions,
     functions: {
       handleChangePlanetInput,
       handleChangeActualNumericFilter,
@@ -32,11 +33,9 @@ function FilterForm() {
           name="column"
           onChange={ handleChangeActualNumericFilter }
         >
-          <option value="population">population</option>
-          <option value="orbital_period">orbital_period</option>
-          <option value="diameter">diameter</option>
-          <option value="rotation_period">rotation_period</option>
-          <option value="surface_water">surface_water</option>
+          {columnOptions.map((option) => (
+            <option key={ option } value={ option }>{option }</option>
+          ))}
         </select>
       </label>
       <label htmlFor="comparison-filter">

--- a/src/contextAPI/ContextProvider.js
+++ b/src/contextAPI/ContextProvider.js
@@ -18,8 +18,6 @@ function PlanetsProvider({ children }) {
     value: '',
   });
 
-  const [buttonIsClicked, setButtonIsClicked] = useState(false);
-
   const getPlanets = async () => {
     const fetchedPlanets = await fetchStarWarsPlanets();
     setPlanets(fetchedPlanets);
@@ -42,29 +40,10 @@ function PlanetsProvider({ children }) {
   };
 
   const handleClickNumericFilter = () => {
-    // const filteredPlanets = planets.filter(({ name }) => (
-    //   name.toLowerCase().includes(planetNameInput.toLowerCase())))
-    //   .filter((planet, index, lastFilteredPlanets) => {
-    //     const searchKeyValue = Number(Object.entries(planet)
-    //       .find(([key]) => key === actualNumericFilter.column)[1]);
-
-    //     switch (actualNumericFilter.comparison) {
-    //     case 'maior que':
-    //       return searchKeyValue > Number(actualNumericFilter.value);
-    //     case 'menor que':
-    //       return searchKeyValue < Number(actualNumericFilter.value);
-    //     case 'igual a':
-    //       return searchKeyValue === Number(actualNumericFilter.value);
-    //     default:
-    //       return lastFilteredPlanets;
-    //     }
-    //   });
     setFilterByNumericValues([...filterByNumericValues, actualNumericFilter]);
+
     setColumnOptions(columnOptions
       .filter((option) => option !== actualNumericFilter.column));
-    setButtonIsClicked(true);
-
-    // setFilteredData(filteredPlanets);
   };
 
   useEffect(() => {
@@ -75,44 +54,24 @@ function PlanetsProvider({ children }) {
   }, [columnOptions]);
 
   useEffect(() => { // Sempre que o estado planetNameInput e o planets são modificados um novo array de planetas é gerado de acordo com o filtro do input
-    // const filteredPlanets = planets.filter(({ name }) => (
-    //   name.toLocaleLowerCase().includes(planetNameInput.toLocaleLowerCase()))); // filtro pelo nome do planeta
-    // setFilteredData(filteredPlanets);
-    const filteredPlanets = planets.filter(({ name }) => (
-      name.toLowerCase().includes(planetNameInput.toLowerCase())))
-      .filter((planet, index, lastFilteredPlanets) => {
-        if (!buttonIsClicked) return lastFilteredPlanets;
+    // Peguei a referencia do filtro dos numericValues do repositório da Julia Baptista!
+    const comparisonHandler = {
+      'maior que': (firstNumber, secondNumber) => firstNumber > secondNumber,
+      'menor que': (firstNumber, secondNumber) => firstNumber < secondNumber,
+      'igual a': (firstNumber, secondNumber) => firstNumber === secondNumber,
+    };
 
-        const [planetKey, planetValue] = Object.entries(planet)
-          .find(([key]) => key === filterByNumericValues[0].column);
-        console.log(planetKey);
-        switch (filterByNumericValues[0].comparison) {
-        case 'maior que':
-          return planetValue > filterByNumericValues[0].value;
-        case 'menor que':
-          return planetValue < filterByNumericValues[0].value;
-        case 'igual a':
-          return planetValue === filterByNumericValues[0].value;
-        default:
-          return lastFilteredPlanets;
-        }
-      });
+    const filteredPlanets = planets.filter((planet) => {
+      const filterByName = planet.name.toLowerCase()
+        .includes(planetNameInput.toLowerCase());
 
-      // .filter((planet, index, lastFilteredPlanets) => {
-      //   if (!buttonIsClicked) return lastFilteredPlanets;
-      //   const searchKeyValue = Number(Object.entries(planet)
-      //     .find(([key]) => key === actualNumericFilter.column)[1]);
-      //   switch (actualNumericFilter.comparison) {
-      //   case 'maior que':
-      //     return searchKeyValue > Number(actualNumericFilter.value);
-      //   case 'menor que':
-      //     return searchKeyValue < Number(actualNumericFilter.value);
-      //   case 'igual a':
-      //     return searchKeyValue === Number(actualNumericFilter.value);
-      //   default:
-      //     return lastFilteredPlanets;
-      //   }
-      // });
+      const filterByNumericValue = filterByNumericValues
+        .every(({ column, comparison, value }) => (
+          comparisonHandler[comparison](Number(planet[column]), Number(value))
+        ));
+
+      return filterByName && filterByNumericValue;
+    });
 
     setFilteredData(filteredPlanets);
   }, [planetNameInput, planets, filterByNumericValues]);

--- a/src/contextAPI/ContextProvider.js
+++ b/src/contextAPI/ContextProvider.js
@@ -7,18 +7,18 @@ function PlanetsProvider({ children }) {
   const [planets, setPlanets] = useState([]);
   const [planetNameInput, setPlanetInput] = useState('');
   const [filteredData, setFilteredData] = useState([]);
-  // const [filterByNumericValues, setFilterByNumericValues] = useState([
-  //   {
-  //     column: 'population',
-  //     comparison: 'maior que',
-  //     value: '',
-  //   },
-  // ]);
+  const [filterByNumericValues, setFilterByNumericValues] = useState([]);
+  const [columnOptions, setColumnOptions] = useState([
+    'population', 'orbital_period',
+    'diameter', 'rotation_period', 'surface_water',
+  ]);
   const [actualNumericFilter, setActualNumericFilter] = useState({
     column: 'population',
     comparison: 'maior que',
     value: '',
   });
+
+  const [buttonIsClicked, setButtonIsClicked] = useState(false);
 
   const getPlanets = async () => {
     const fetchedPlanets = await fetchStarWarsPlanets();
@@ -42,37 +42,86 @@ function PlanetsProvider({ children }) {
   };
 
   const handleClickNumericFilter = () => {
-    const filteredPlanets = planets.filter(({ name }) => (
-      name.toLocaleLowerCase().includes(planetNameInput.toLocaleLowerCase())))
-      .filter((planet) => {
-        const searchKeyValue = Number(Object.entries(planet)
-          .find(([key]) => key === actualNumericFilter.column)[1]);
+    // const filteredPlanets = planets.filter(({ name }) => (
+    //   name.toLowerCase().includes(planetNameInput.toLowerCase())))
+    //   .filter((planet, index, lastFilteredPlanets) => {
+    //     const searchKeyValue = Number(Object.entries(planet)
+    //       .find(([key]) => key === actualNumericFilter.column)[1]);
 
-        switch (actualNumericFilter.comparison) {
+    //     switch (actualNumericFilter.comparison) {
+    //     case 'maior que':
+    //       return searchKeyValue > Number(actualNumericFilter.value);
+    //     case 'menor que':
+    //       return searchKeyValue < Number(actualNumericFilter.value);
+    //     case 'igual a':
+    //       return searchKeyValue === Number(actualNumericFilter.value);
+    //     default:
+    //       return lastFilteredPlanets;
+    //     }
+    //   });
+    setFilterByNumericValues([...filterByNumericValues, actualNumericFilter]);
+    setColumnOptions(columnOptions
+      .filter((option) => option !== actualNumericFilter.column));
+    setButtonIsClicked(true);
+
+    // setFilteredData(filteredPlanets);
+  };
+
+  useEffect(() => {
+    setActualNumericFilter({
+      ...actualNumericFilter,
+      column: columnOptions[0],
+    });
+  }, [columnOptions]);
+
+  useEffect(() => { // Sempre que o estado planetNameInput e o planets são modificados um novo array de planetas é gerado de acordo com o filtro do input
+    // const filteredPlanets = planets.filter(({ name }) => (
+    //   name.toLocaleLowerCase().includes(planetNameInput.toLocaleLowerCase()))); // filtro pelo nome do planeta
+    // setFilteredData(filteredPlanets);
+    const filteredPlanets = planets.filter(({ name }) => (
+      name.toLowerCase().includes(planetNameInput.toLowerCase())))
+      .filter((planet, index, lastFilteredPlanets) => {
+        if (!buttonIsClicked) return lastFilteredPlanets;
+
+        const [planetKey, planetValue] = Object.entries(planet)
+          .find(([key]) => key === filterByNumericValues[0].column);
+        console.log(planetKey);
+        switch (filterByNumericValues[0].comparison) {
         case 'maior que':
-          return searchKeyValue > Number(actualNumericFilter.value);
+          return planetValue > filterByNumericValues[0].value;
         case 'menor que':
-          return searchKeyValue < Number(actualNumericFilter.value);
+          return planetValue < filterByNumericValues[0].value;
         case 'igual a':
-          return searchKeyValue === Number(actualNumericFilter.value);
+          return planetValue === filterByNumericValues[0].value;
         default:
-          return '';
+          return lastFilteredPlanets;
         }
       });
 
-    setFilteredData(filteredPlanets);
-  };
+      // .filter((planet, index, lastFilteredPlanets) => {
+      //   if (!buttonIsClicked) return lastFilteredPlanets;
+      //   const searchKeyValue = Number(Object.entries(planet)
+      //     .find(([key]) => key === actualNumericFilter.column)[1]);
+      //   switch (actualNumericFilter.comparison) {
+      //   case 'maior que':
+      //     return searchKeyValue > Number(actualNumericFilter.value);
+      //   case 'menor que':
+      //     return searchKeyValue < Number(actualNumericFilter.value);
+      //   case 'igual a':
+      //     return searchKeyValue === Number(actualNumericFilter.value);
+      //   default:
+      //     return lastFilteredPlanets;
+      //   }
+      // });
 
-  useEffect(() => { // Sempre que o estado planetNameInput e o planets são modificados um novo array de planetas é gerado de acordo com o filtro do input
-    const filteredPlanets = planets.filter(({ name }) => (
-      name.toLocaleLowerCase().includes(planetNameInput.toLocaleLowerCase()))); // filtro pelo nome do planeta
     setFilteredData(filteredPlanets);
-  }, [planetNameInput, planets]);
+  }, [planetNameInput, planets, filterByNumericValues]);
 
   const contextValue = {
     data: planets,
     filteredData,
     actualNumericFilter,
+    columnOptions,
     filters: {
       filterByName: {
         name: planetNameInput,


### PR DESCRIPTION
Por exemplo: O primeiro filtro tem as seguintes seleções:  `population | maior que | 100000`. Um segundo filtro deve aparecer após essas seleções serem todas feitas e, no primeiro dropdown deste segundo filtro, a opção  `population`  deve estar ausente. Se no segundo filtro fosse selecionado  `diameter | menor que | 8000`, o estado ficaria assim:

```jsx
{
  filters: {
    filterByName: {
      name: ''
    },
    filterByNumericValues: [
      {
        column: 'population',
        comparison: 'maior que',
        value: '100000',
      },
      {
        column: 'diameter',
        comparison: 'menor que',
        value: '8000',
      }
    ]
  }
}

```

O que será verificado:

```
- Filtra por população e o remove das opções

```